### PR TITLE
version bump

### DIFF
--- a/module.yml
+++ b/module.yml
@@ -1,7 +1,7 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: apache
-version: 0.5.0
+version: 0.5.1.dev1588766575
 requires:
 - web
 - std


### PR DESCRIPTION
The latest release tag points to 3ecc6a5 which contains a syntax error. Somehow a similar commit (f5252b3) without the syntax error is present on master.